### PR TITLE
fix for getting stuck in the loop while doing bulk creation

### DIFF
--- a/Randomizer/StartersGifts/randomize_starters.py
+++ b/Randomizer/StartersGifts/randomize_starters.py
@@ -95,7 +95,7 @@ def randomize_starter(config, pokemon_entry, check_forced_shiny: int, allowed_po
     if (check_forced_shiny == 0 and config['make_all_starters_shiny'] != "yes"
             and config['higher_chance_shiny'] == "yes"):
         shiny_chance = random.randint(1, sharedVar.boostedshiny)
-        if shiny_chance == 7:
+        if shiny_chance == 1:
             pokemon_entry['pokeData']['rareType'] = "RARE"
 
     # Change Pokeball

--- a/Randomizer/StaticFights/randomize_fights.py
+++ b/Randomizer/StaticFights/randomize_fights.py
@@ -111,11 +111,23 @@ def randomize_specific_fight(pokedata, allowed_pokemon: list):
     pokedata['pokeData']['item'] = HelperFunctions.get_pokemon_item_form(choice, form_id)[0]
     pokedata['pokeData']['wazaType'] = "DEFAULT"
     shiny_change = random.randint(1, SharedVariables.boostedshiny)
-    if shiny_change == 7:
+    if shiny_change == 1:
         pokedata['pokeData']['rareType'] = "RARE"
     for i in range(1, 5):
         pokedata['pokeData'][f'waza{str(i)}']['wazaId'] = "WAZA_NULL"
     return pokedata
+
+
+def spoiler_statics_data(spoilers, mondata):
+    spoilers.write("\n"+mondata['label']+" = Lvl "+str(mondata['pokeData']['level'])+" "+HelperFunctions.get_monname(HelperFunctions.get_monid(mondata['pokeData']['devId']))+HelperFunctions.get_form_txt(mondata['pokeData']['formId']))
+    if mondata['pokeData']['rareType'] != 'NO_RARE':
+        if mondata['pokeData']['rareType'] =='RARE':
+            spoilers.write(" !!!SHINY!!!")
+        else:
+            spoilers.write(" "+mondata['pokeData']['rareType'])
+            
+    spoilers.write("\nTera: "+HelperFunctions.get_gem_txt(mondata['pokeData']['gemType']))
+    spoilers.write(" | "+HelperFunctions.basestat_txt(mondata['pokeData']['talentValue']))
 
 
 def randomize_static_fights(config):
@@ -174,6 +186,7 @@ def randomize_static_fights(config):
 
         allowed_pokemon, allowed_legends, bpl = HelperFunctions.check_generation_limiter(config['generation_limiter'])
         if config['randomize_all'] == "yes":
+            spoilers = HelperFunctions.spoilerlog("Statics")
             for i in range(0, len(file_json['values'])):
                 # Also all DLC Fights
                 if i == 31 or i == 32:
@@ -292,6 +305,7 @@ def randomize_static_fights(config):
                 #         file_json['values'][i]['pokeData'][f'waza{str(k)}']['wazaId'] = "WAZA_NULL"
                 else:
                     randomize_specific_fight(file_json['values'][i], allowed_pokemon)
+                spoiler_statics_data(spoilers, file_json['values'][i])
 
             outdata = json.dumps(file_json, indent=2)
             with open(os.getcwd() + "/Randomizer/StaticFights/" + "eventBattlePokemon_array.json", 'w') as outfile:
@@ -685,7 +699,7 @@ def randomize_static_fights(config):
             shutil.copyfile(os.getcwd() + "/Randomizer/Scenes/Misc/Sunflora/pokes_1.trsog",
                             os.getcwd() + "/output/romfs/" + paths['sunflora'] + 'pokes_1.trsog')
 
-
+        spoilers.close()
         print("Randomization Of Static Fights Pokemon Done!")
         return True
     return False

--- a/Randomizer/TMs/randomize_tms.py
+++ b/Randomizer/TMs/randomize_tms.py
@@ -11,6 +11,7 @@ def randomize_tms(config):
         movesfile = HelperFunctions.open_json_file('TMs/move_list.json')
         move_count = len(movesfile['moves']) - 1
         spoilers = HelperFunctions.spoilerlog("TM Changes")
+        SharedVariables.usedMoves = []
         for item in tmsfile['values']:
             if item['ItemType'] == "ITEMTYPE_WAZA" and item['Id'] != 1230:
                 rand = random.randint(0, move_count)

--- a/Randomizer/helper_function.py
+++ b/Randomizer/helper_function.py
@@ -799,6 +799,12 @@ def seedgen(fixed_seed):
     print("Seed is: ", seed)
     return seed
 
+def basestat_txt(stats):
+    if stats:
+        return "hp:"+str(stats['hp'])+" atk:"+str(stats['atk'])+" def:"+str(stats['def'])+" spAtk:"+str(stats['spAtk'])+" spDef:"+str(stats['spDef'])+" spe: "+str(stats['agi'])
+    else:
+        return "Stats error"
+
 def fix_config(config):
     if "shiny_boosted_rate" not in config:
         config["shiny_boosted_rate"] = 10


### PR DESCRIPTION
randomize_tms.py
-added line to clear SharedVariables.usedMoves to ensure its fresh for each iteration of a bulk creation

with bulk it was filling the list each time but not emptying it before the next time it needed to use it which after a few creations would fill with all possible moves leaving no more to be found

also includes shiny check fix for boosted rates higher than 1 in 7

Also added spoilers.log entry for static encounters