### PR TITLE
Trainer level boost, Spoiler/evo/type/list fixes and error handling amendments

### DIFF
--- a/Randomizer.py
+++ b/Randomizer.py
@@ -16,10 +16,11 @@ import Randomizer.helper_function as HelperFunctions
 import Randomizer.TMs.randomize_tms as TMsRandomizer
 import shutil
 
-current_version_txt = '1.1.3-re-release'
+current_version_txt = '1.1.4a-OndoBranch'
 
 def check_updates():
     print("Checking for Updates")
+    print("Current version: " +current_version_txt)
     url = "https://api.github.com/repos/Gonzalooo/Scarlet-and-Violet-Randomizer/releases/latest"
     scrapped_response = requests.get(url)
     formated_response = scrapped_response.json()

--- a/Randomizer/Items/itemrandomizer.py
+++ b/Randomizer/Items/itemrandomizer.py
@@ -42,6 +42,7 @@ def randomizeHiddenItems():
     spoilers = HelperFunctions.spoilerlog("Hidden Items")
     spoilers.write("\n-----------------\nPaldea Hidden\n-----------------\n")
     for i in range(0, len(paldeaItems['values'])):
+        spoilers.write("Group "+str(i)+"\n")
         for j in range(1, 11):
             itemChoice = random.randint(1, 1090)
             while (itemData['items'][itemChoice]['ItemType'] == "ITEMTYPE_MATERIAL" or
@@ -54,11 +55,12 @@ def randomizeHiddenItems():
             paldeaItems['values'][i][f'item_{str(j)}']['itemId'] = picked_devname
             paldeaItems['values'][i][f'item_{str(j)}']['emergePercent'] = random.randint(100, 1000)
             paldeaItems['values'][i][f'item_{str(j)}']['dropCount'] = random.randint(1, 20)
-            spoilers.write(HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' | '+str(paldeaItems['values'][i][f'item_{str(j)}']['dropCount'])+' | '+str(paldeaItems['values'][i][f'item_{str(j)}']['emergePercent'])+'\n')
+            spoilers.write(str(paldeaItems['values'][i][f'item_{str(j)}']['emergePercent']/10)+"% "+HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' x'+str(paldeaItems['values'][i][f'item_{str(j)}']['dropCount'])+'\n')
         #print(paldeaItems['values'][i])
 
     spoilers.write("\n-----------------\nKitaKami Hidden\n-----------------\n")
     for i in range(0, len(kitakamiItems['values'])):
+        spoilers.write("Group "+str(i)+"\n")
         for j in range(1, 11):
             itemChoice = random.randint(1, 1090)
             while (itemData['items'][itemChoice]['ItemType'] == "ITEMTYPE_MATERIAL" or
@@ -71,11 +73,12 @@ def randomizeHiddenItems():
             kitakamiItems['values'][i][f'item_{str(j)}']['itemId'] = picked_devname
             kitakamiItems['values'][i][f'item_{str(j)}']['emergePercent'] = random.randint(100, 1000)
             kitakamiItems['values'][i][f'item_{str(j)}']['dropCount'] = random.randint(1, 20)
-            spoilers.write(HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' | '+str(kitakamiItems['values'][i][f'item_{str(j)}']['dropCount'])+' | '+str(kitakamiItems['values'][i][f'item_{str(j)}']['emergePercent'])+'\n')
+            spoilers.write(str(kitakamiItems['values'][i][f'item_{str(j)}']['emergePercent']/10)+"% "+HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' x'+str(kitakamiItems['values'][i][f'item_{str(j)}']['dropCount'])+'\n')
         #print(kitakamiItems['values'][i])
 
     spoilers.write("\n-----------------\nBlueberry Hidden\n-----------------\n")
     for i in range(0, len(blueberryItems['values'])):
+        spoilers.write("Group "+str(i)+"\n")
         for j in range(1, 11):
             itemChoice = random.randint(1, 1090)
             while (itemData['items'][itemChoice]['ItemType'] == "ITEMTYPE_MATERIAL" or
@@ -88,11 +91,12 @@ def randomizeHiddenItems():
             blueberryItems['values'][i][f'item_{str(j)}']['itemId'] = picked_devname
             blueberryItems['values'][i][f'item_{str(j)}']['emergePercent'] = random.randint(100, 1000)
             blueberryItems['values'][i][f'item_{str(j)}']['dropCount'] = random.randint(1, 20)
-            spoilers.write(HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' | '+str(blueberryItems['values'][i][f'item_{str(j)}']['dropCount'])+' | '+str(blueberryItems['values'][i][f'item_{str(j)}']['emergePercent'])+'\n')
+            spoilers.write(str(blueberryItems['values'][i][f'item_{str(j)}']['emergePercent']/10)+"% "+HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' x'+str(blueberryItems['values'][i][f'item_{str(j)}']['dropCount'])+'\n')
         #print(blueberryItems['values'][i])
 
     spoilers.write("\n-----------------\nLC Hidden\n-----------------\n")
     for i in range(0, len(lcItems['values'])):
+        spoilers.write("Group "+str(i)+"\n")
         for j in range(1, 11):
             itemChoice = random.randint(1, 1090)
             while (itemData['items'][itemChoice]['ItemType'] == "ITEMTYPE_MATERIAL" or
@@ -105,7 +109,7 @@ def randomizeHiddenItems():
             lcItems['values'][i][f'item_{str(j)}']['itemId'] = picked_devname
             lcItems['values'][i][f'item_{str(j)}']['emergePercent'] = random.randint(100, 1000)
             lcItems['values'][i][f'item_{str(j)}']['dropCount'] = random.randint(1, 20)
-            spoilers.write(HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' | '+str(lcItems['values'][i][f'item_{str(j)}']['dropCount'])+' | '+str(lcItems['values'][i][f'item_{str(j)}']['emergePercent'])+'\n')
+            spoilers.write(str((lcItems['values'][i][f'item_{str(j)}']['emergePercent']/10))+"% "+HelperFunctions.get_itemname(HelperFunctions.get_itemid(picked_devname))+' x'+str(lcItems['values'][i][f'item_{str(j)}']['dropCount'])+'\n')
         #print(lcItems['values'][i])
 
     outdata = json.dumps(lcItems, indent=2)

--- a/Randomizer/Scenes/patchscene.py
+++ b/Randomizer/Scenes/patchscene.py
@@ -35,6 +35,18 @@ def retrieve_catalog_entry(catalog: dict, species, form, fake_catalog_index):
 def create_new_file_for_shiny(catalog: dict, key_change: str, file_num: int):
     # print(key_change)
     # print(file_num)
+    if catalog is None:
+        print("'Random' Error Caught, currently unsure of the cause")
+        print("currently no fix other than to close window and try with a new seed sorry")
+        breakpoint()
+    if key_change is None:
+        print("'Random' Error Caught, currently unsure of the cause")
+        print("currently no fix other than to close window and try with a new seed sorry")
+        breakpoint()
+    if key_change not in catalog:
+        print("'Random' Error Caught, currently unsure of the cause")
+        print("currently no fix other than to close window and try with a new seed sorry")
+        breakpoint()
     new_file_name = catalog[key_change].split('/')
     new_file_name[0] = f'pm{file_num}'
     new_file_name = '/'.join(new_file_name)
@@ -82,9 +94,10 @@ def flip_starter_texture(starter_num: int, fake_entry: int):
                     shutil.copy2(ogfiledir, newfiledir)
         return True
     except Exception as e:
-        print(f'ERROR FOR: {pokemon_file} - the fake entry of {fake_entry}')
-        print("ERROR - NO FILES IN POKEMON_CLEAN - SHINY STARTER WILL USE REGULAR TEXTURE - FIX FOR NEXT TIME.")
-        print(traceback.print_exc())
+        print(f'Missing folder: {pokemon_file} - the fake entry of {fake_entry}')
+        print("Optional pokemon_clean folder not setup or incomplete")
+        print("Model may not appear changed/shiny until caught")
+        #print(traceback.print_exc())
     return False
 
 

--- a/Randomizer/helper_function.py
+++ b/Randomizer/helper_function.py
@@ -664,7 +664,7 @@ def generate_binary(schema: str, json_file: str, path: str, debug=False):
     return proc
 
 def spoilerindex(rngseed, versiontxt):
-    f = open("spoilers.log", "a")#Open/create spoiler log and start new header
+    f = open("spoilers.log", "a", encoding='utf-8')#Open/create spoiler log and start new header
     f.write("\n\n---------------------------\n"+
 "Spoiler Log Index"+
 "\n---------------------------\n"+
@@ -701,7 +701,7 @@ def spoilerindex(rngseed, versiontxt):
 
 
 def spoilerlog(title: str):
-    f = open("spoilers.log", "a")#Open/create spoiler log and start new header
+    f = open("spoilers.log", "a", encoding='utf-8')#Open/create spoiler log and start new header
     f.write("\n\n---------------------------\n")
     f.write("| "+title+" |\n")
     f.write("---------------------------\n")
@@ -770,6 +770,9 @@ def get_monid(devname: str):
     else:
         return SharedVariables.monids[devname]
         
+def get_type_txt(montype: int):
+    return SharedVariables.tera_types_eng[montype]
+    
 def get_gem_txt(gem: str):
     if gem.lower() == "default":
         return gem
@@ -808,6 +811,13 @@ def basestat_txt(stats):
 def fix_config(config):
     if "shiny_boosted_rate" not in config:
         config["shiny_boosted_rate"] = 10
+        print("config option not found: 'shiny_boosted_rate'")
+        print("defaulting to 1 in 10 chance to be shiny... where possible")
+        
+    if "percent_chance_dual_type" not in config['pokemon_stats_randomizer']:
+        config['pokemon_stats_randomizer']["percent_chance_dual_type"] = 60
+        print("config option not found: 'pokemon_stats_randomizer''percent_chance_dual_type'")
+        print("defaulting to 60% chance to be dual type")
         
     if "exclude_legendaries" not in config['kitakami_settings']['wild_randomizer']:
         if "exclude_legendary" in config['kitakami_settings']['wild_randomizer']:
@@ -829,7 +839,43 @@ def fix_config(config):
         else:
             _gettxt = "no"
         config['starter_pokemon_randomizer']['show_shiny_starters_in_overworld'] = _gettxt
-    
+        
+    isthere = False
+    if "boostpercent" not in config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostpercent"] = 10
+        isthere = True
+    if "boostpercent" not in config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostpercent"] = 10
+        isthere = True
+    if "boostpercent" not in config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostpercent"] = 10
+        isthere = True
+    if isthere == True:
+        print("config option not found: 'boostpercent' in 'all_trainers_settings' section(s)")
+        print("defaulting to 10% boost")
+        print("NOTE: boostlevels still needs to be yes for this to apply")
+        
+    isthere = False
+    if "boostlevels" not in config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostlevels"] = "no"
+        isthere = True
+    if "boostlevels" not in config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostlevels"] = "no"
+        isthere = True
+    if "boostlevels" not in config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]["boostlevels"] = "no"
+        isthere = True
+    if isthere == True:
+        print("config option not found: 'boostlevels' in 'all_trainers_settings' section(s)")
+        print("defaulting to no level boosting for trainers")
+        
+    if "useondomathforboost" not in config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["paldea_settings"]["trainers_randomizer"]["all_trainers_settings"]["useondomathforboost"] = "no"
+    if "useondomathforboost" not in config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["kitakami_settings"]["trainers_randomizer"]["all_trainers_settings"]["useondomathforboost"] = "no"
+    if "useondomathforboost" not in config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]:
+        config["blueberry_settings"]["trainers_randomizer"]["all_trainers_settings"]["useondomathforboost"] = "no"
+        
     #writes the changes to file, writes to the bottom of file unsure if there is a way around it to make it more user friendly, disabled for now
     #with open('new_config.json', 'w', encoding='utf-8') as f:
     #    json.dump(config, f, ensure_ascii=False, indent=2)

--- a/Randomizer/shared_Variables.py
+++ b/Randomizer/shared_Variables.py
@@ -100,14 +100,14 @@ banned_pokemon = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 29, 30, 31
                   809, 824, 825, 826, 827, 828, 829, 830, 831, 832, 835, 836, 850, 851, 852, 853, 864, 865, 866, 867,
                   880, 881, 882, 883, 862]
 legends = [144, 145, 146, 150, 151, 243, 244, 245, 249, 250, 251, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 480,
-           481, 482, 483, 484, 485, 486, 487, 489, 490, 491, 492, 493, 494, 638, 639, 640, 641, 642, 643, 644, 645, 646,
-           647, 648, 649, 716, 717, 718, 719, 720, 721, 785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808,
+           481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 638, 639, 640, 641, 642, 643, 644, 645, 646,
+           647, 648, 649, 716, 717, 718, 719, 720, 721, 772, 773, 785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808,
            809, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 905, 1001, 1002, 1003, 1004, 1007, 1008, 1009,
            1010, 1014, 1015, 1016, 1017, 1020, 1021, 1022, 1023, 1024, 1025]
 legends_and_paradox = [
            144, 145, 146, 150, 151, 243, 244, 245, 249, 250, 251, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 480,
-           481, 482, 483, 484, 485, 486, 487, 489, 490, 491, 492, 493, 494, 638, 639, 640, 641, 642, 643, 644, 645, 646,
-           647, 648, 649, 716, 717, 718, 719, 720, 721, 785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808,
+           481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 638, 639, 640, 641, 642, 643, 644, 645, 646,
+           647, 648, 649, 716, 717, 718, 719, 720, 721, 772, 773, 785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808,
            809, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 905, 984, 985, 986, 987, 988, 989, 990, 991, 992,
            993, 994, 995, 1005, 1006, 1001, 1002, 1003, 1004, 1007, 1008, 1009, 1010, 1014, 1015, 1016, 1017, 1020, 1021,
            1022, 1023, 1024, 1025]
@@ -117,12 +117,12 @@ gen3_legends = [377, 378, 379, 380, 381, 382, 383, 384, 385, 386]
 gen4_legends = [480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493]
 gen5_legends = [494, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649]
 gen6_legends = [716, 717, 718, 719, 720, 721]
-gen7_legends = [785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808, 809]
+gen7_legends = [772, 773, 785, 786, 787, 788, 789, 790, 791, 792, 800, 801, 802, 807, 808, 809]
 UB = [793, 794, 795, 796, 797, 798, 799, 803, 804, 805, 806]
 gen8_legends = [888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 905]
 gen9_legends = [1001, 1002, 1003, 1004, 1007, 1008, 1009, 1010, 1014, 1015, 1016, 1017, 1020, 1021, 1022, 1023, 1024, 1025]
 paradox = [984, 985, 986, 987, 988, 989, 990, 991, 992, 993, 994, 995, 1005, 1006, 1007, 1008, 1009, 1010, 1020, 1021,
-           1022, 1023, 1024]
+           1022, 1023]
 gen1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
         31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
@@ -389,7 +389,7 @@ has_alternate_form = [25,  # Pikachu - Caps + Partner
 
 area_zero_locations = ["a_w23_d01", "a_w23_d02", "a_w23_d03", "a_w23_d04", "a_w23_field_1",
                        "a_w23_field_2", "a_w23_field_3"]
-
+    
 pokemon_with_regional_evolutions = [
     25,   # Pikachu [1]
     102,  # Exeggcute [1]
@@ -443,6 +443,12 @@ movenames = {}
 movedevnames = {}
 monnames = {}
 monids = {}
-tera_types_eng = ['Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass',
-              'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark', 'Fairy', 'Stellar']
+tera_types_eng = ['Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark', 'Fairy', 'Stellar']
+              
 boostedshiny = 4096
+boosted_lvl_b = 1.0214
+boosted_lvl_a = 0.979
+
+biomes_list = ["GRASS", "FOREST", "SWAMP", "LAKE", "TOWN", "MOUNTAIN", "BAMBOO", "MINE", "CAVE", "OLIVE", "UNDERGROUND", "RIVER", "ROCKY", "BEACH", "SNOW", "OSEAN", "RUINS", "FLOWER"]
+
+ability_list = ["None", "Stench", "Drizzle", "Speed Boost", "Battle Armor", "Sturdy", "Damp", "Limber", "Sand Veil", "Static", "Volt Absorb", "Water Absorb", "Oblivious", "Cloud Nine", "Compound Eyes", "Insomnia", "Color Change", "Immunity", "Flash Fire", "Shield Dust", "Own Tempo", "Suction Cups", "Intimidate", "Shadow Tag", "Rough Skin", "Wonder Guard", "Levitate", "Effect Spore", "Synchronize", "Clear Body", "Natural Cure", "Lightning Rod", "Serene Grace", "Swift Swim", "Chlorophyll", "Illuminate", "Trace", "Huge Power", "Poison Point", "Inner Focus", "Magma Armor", "Water Veil", "Magnet Pull", "Soundproof", "Rain Dish", "Sand Stream", "Pressure", "Thick Fat", "Early Bird", "Flame Body", "Run Away", "Keen Eye", "Hyper Cutter", "Pickup", "Truant", "Hustle", "Cute Charm", "Plus", "Minus", "Forecast", "Sticky Hold", "Shed Skin", "Guts", "Marvel Scale", "Liquid Ooze", "Overgrow", "Blaze", "Torrent", "Swarm", "Rock Head", "Drought", "Arena Trap", "Vital Spirit", "White Smoke", "Pure Power", "Shell Armor", "Air Lock", "Tangled Feet", "Motor Drive", "Rivalry", "Steadfast", "Snow Cloak", "Gluttony", "Anger Point", "Unburden", "Heatproof", "Simple", "Dry Skin", "Download", "Iron Fist", "Poison Heal", "Adaptability", "Skill Link", "Hydration", "Solar Power", "Quick Feet", "Normalize", "Sniper", "Magic Guard", "No Guard", "Stall", "Technician", "Leaf Guard", "Klutz", "Mold Breaker", "Super Luck", "Aftermath", "Anticipation", "Forewarn", "Unaware", "Tinted Lens", "Filter", "Slow Start", "Scrappy", "Storm Drain", "Ice Body", "Solid Rock", "Snow Warning", "Honey Gather", "Frisk", "Reckless", "Multitype", "Flower Gift", "Bad Dreams", "Pickpocket", "Sheer Force", "Contrary", "Unnerve", "Defiant", "Defeatist", "Cursed Body", "Healer", "Friend Guard", "Weak Armor", "Heavy Metal", "Light Metal", "Multiscale", "Toxic Boost", "Flare Boost", "Harvest", "Telepathy", "Moody", "Overcoat", "Poison Touch", "Regenerator", "Big Pecks", "Sand Rush", "Wonder Skin", "Analytic", "Illusion", "Imposter", "Infiltrator", "Mummy", "Moxie", "Justified", "Rattled", "Magic Bounce", "Sap Sipper", "Prankster", "Sand Force", "Iron Barbs", "Zen Mode", "Victory Star", "Turboblaze", "Teravolt", "Aroma Veil", "Flower Veil", "Cheek Pouch", "Protean", "Fur Coat", "Magician", "Bulletproof", "Competitive", "Strong Jaw", "Refrigerate", "Sweet Veil", "Stance Change", "Gale Wings", "Mega Launcher", "Grass Pelt", "Symbiosis", "Tough Claws", "Pixilate", "Gooey", "Aerilate", "Parental Bond", "Dark Aura", "Fairy Aura", "Aura Break", "Primordial Sea", "Desolate Land", "Delta Stream", "Stamina", "Wimp Out", "Emergency Exit", "Water Compaction", "Merciless", "Shields Down", "Stakeout", "Water Bubble", "Steelworker", "Berserk", "Slush Rush", "Long Reach", "Liquid Voice", "Triage", "Galvanize", "Surge Surfer", "Schooling", "Disguise", "Battle Bond", "Power Construct", "Corrosion", "Comatose", "Queenly Majesty", "Innards Out", "Dancer", "Battery", "Fluffy", "Dazzling", "Soul-Heart", "Tangling Hair", "Receiver", "Power of Alchemy", "Beast Boost", "RKS System", "Electric Surge", "Psychic Surge", "Misty Surge", "Grassy Surge", "Full Metal Body", "Shadow Shield", "Prism Armor", "Neuroforce", "Intrepid Sword", "Dauntless Shield", "Libero", "Ball Fetch", "Cotton Down", "Propeller Tail", "Mirror Armor", "Gulp Missile", "Stalwart", "Steam Engine", "Punk Rock", "Sand Spit", "Ice Scales", "Ripen", "Ice Face", "Power Spot", "Mimicry", "Screen Cleaner", "Steely Spirit", "Perish Body", "Wandering Spirit", "Gorilla Tactics", "Neutralizing Gas", "Pastel Veil", "Hunger Switch", "Quick Draw", "Unseen Fist", "Curious Medicine", "Transistor", "Dragon’s Maw", "Chilling Neigh", "Grim Neigh", "As One", "As One", "Lingering Aroma", "Seed Sower", "Thermal Exchange", "Anger Shell", "Purifying Salt", "Well-Baked Body", "Wind Rider", "Guard Dog", "Rocky Payload", "Wind Power", "Zero to Hero", "Commander", "Electromorphosis", "Protosynthesis", "Quark Drive", "Good as Gold", "Vessel of Ruin", "Sword of Ruin", "Tablets of Ruin", "Beads of Ruin", "Orichalcum Pulse", "Hadron Engine", "Opportunist", "Cud Chew", "Sharpness", "Supreme Overlord", "Costar", "Toxic Debris", "Armor Tail", "Earth Eater", "Mycelium Might", "Hospitality", "Mind’s Eye", "Embody Aspect", "Embody Aspect", "Embody Aspect", "Embody Aspect", "Toxic Chain", "Supersweet Syrup", "Tera Shift", "Tera Shell", "Teraform Zero", "Poison Puppeteer"]

--- a/new_config.json
+++ b/new_config.json
@@ -11,7 +11,7 @@
   "_comment5": "NOTE: the seeds gained from bulk/batch are different than single generation, only the first in the series will match",
   "bulk_creation": {
     "is_enabled": "no",
-    "number_of_unique_randomizers_to_create": 3
+    "number_of_unique_randomizers_to_create": 10
   },
   "items_randomizer": {
     "_comment": "Only works on hidden items - I can't find file for overworld items.",
@@ -27,7 +27,7 @@
       "is_enabled": "yes",
       "randomize_abilities": "yes",
       "randomize_types": "yes",
-      "randomize_types_count": 2,
+      "percent_chance_dual_type": 60,
       "ban_wonder_guard": "yes",
       "randomize_movesets": "yes",
       "randomize_stats_with_same_total": "no",
@@ -118,8 +118,17 @@
         "allow_shiny_pokemon": "yes",
         "randomnly_choose_single_or_doubles": "no",
         "only_double_battles": "no",
+		"boostlevels": "yes",
+		"boostpercent": 10,
+		"useondomathforboost": "no",
+		"boost_min": 1,
+		"boost_max": 10,
         "_comment": "working on similar BST option",
-        "_comment1": "missing option to have rival starter evolve"
+        "_comment1": "missing option to have rival starter evolve",
+        "_comment2": "boostlevels works on a range, scaling up from lvl 1 to (100 minus boost_max)",
+        "_comment3": "a range of 1 to 10 will mean at lvl 1 they get +1 scaling to at 90 they get +10",
+        "_comment4": "a range of 3 to 25 will mean at lvl 1 they get +3 scaling to at 75 they get +25"
+		
       },
       "rival_randomizer": {
         "_comment": "Includes: Penny, All of TS, Arven, Clavell, and Nemona",
@@ -234,6 +243,11 @@
         "allow_shiny_pokemon": "no",
         "randomnly_choose_single_or_doubles": "no",
         "only_double_battles": "no",
+		"boostlevels": "yes",
+		"boostpercent": 10,
+		"useondomathforboost": "no",
+		"boost_min": 1,
+		"boost_max": 10,
         "_comment": "working on similar BST option"
       },
       "important_trainers_randomizer": {
@@ -327,6 +341,11 @@
         "allow_shiny_pokemon": "no",
         "randomnly_choose_single_or_doubles": "no",
         "only_double_battles": "no",
+		"boostlevels": "yes",
+		"boostpercent": 10,
+		"useondomathforboost": "no",
+		"boost_min": 1,
+		"boost_max": 10,
         "_comment": "working on similar BST option"
       },
       "important_trainers_randomizer": {


### PR DESCRIPTION

trainerrando.py
-Changed trainer levels to be boostable based on a scaling function rather than random increased -Changed extra generated mons to have the same level as the highest mon already on the team -added upper limit on boosted levels to avoid any weirdness with the function creation -corrected issue with levelboost applying when it shouldnt -changed levelboost to use percentage
-disabled but kept other planned level boost scaling details -added debug code for levelboosting disabled for general use

shared_Variables.py
-Added variables for trainer level boosting
-updated lists to include Cresselia, Type: Null and Silvally -removed Terapagos from paradox list
-added new biomes list
-Added ability names list

new_config.json
-removed randomize_types_count
-added percent_chance_dual_type
-Added options for trainer level boosting under all 3 trainer sections -set default for boostlevels to yes since it was already auto applied

Randomizer.py
-changed version to 1.1.4a-OndoBranch
-also update check how outputs current version name to compare to the supposed latest -Fixed issue with Current version display text

helper_function.py
-updated spoiler log open function to force utf-8 encoding to help with windows language incompatibilities -added get_type_txt() which returns the string name of a type -also added config check to ensure change to type randomization is added if an older config is imported -amended fix_config() to include console print out of what its creating entries for -added entries in fix_config() for new lvl boost changes

itemrandomizer.py
-Changed how hidden items are displayed in the spoiler log -Fixed issue with hidden item spoiler log format

personal_randomizer.py
-added is_allowed_to_learn() to ensure moves locked to specific mons arent given to others -changed type randomization to use a percentage chance of being dual type -amended fix_evolutions() to include Koffing -> Galarian Weezing -added check in randomize_pokemon_stats() see if is_present and if not skips randomizing its details -fixed spoiler log showing "on evolution" moves incorrectly -spoiler log now shows mon type in english rather than simply a number -Updated spoiler log to show ability names not simply a number

patchscene.py
-Changed message shown when unable to find pm files to be less alarming -also hid the traceback printout for it
-encountered an error on SOME runs not all, added an error print out and "catch" to work out fully later -tweaked error text for missing pm files